### PR TITLE
Fixing issue #1

### DIFF
--- a/lib/timezones.py
+++ b/lib/timezones.py
@@ -1,6 +1,0 @@
-from flask_babel import to_user_timezone, format_date, format_datetime
-
-
-def to_local_time(t):
-    return to_user_timezone(t).replace(tzinfo=None)
-

--- a/sqlalchemy_serializer/lib/timezones.py
+++ b/sqlalchemy_serializer/lib/timezones.py
@@ -1,0 +1,6 @@
+from flask_babel import to_user_timezone, format_date, format_datetime
+
+
+def to_local_time(t):
+    return to_user_timezone(t).replace(tzinfo=None)
+

--- a/sqlalchemy_serializer/serializer.py
+++ b/sqlalchemy_serializer/serializer.py
@@ -6,7 +6,7 @@ from collections import Iterable
 from types import MethodType
 
 from sqlalchemy import inspect as sql_inspect
-from lib.timezones import to_local_time, format_date, format_datetime
+from .lib.timezones import to_local_time, format_date, format_datetime
 
 
 logger = logging.getLogger('serializer')


### PR DESCRIPTION
This commit fix the location and import of the **lib** module, used for date_time conversion purposes.

Moved module from **/lib** to **/sqlalchemy_serializer/lib**
Changed the import from **lib.timezones** to **.lib.timezones** in serializer.py

The lib needed to be moved because it was not being included in the package installed through pip.
Import changed to comply with https://www.python.org/dev/peps/pep-0404/#imports