### PR TITLE
Added support of `Serializer` subclassing

### DIFF
--- a/sqlalchemy_serializer/serializer.py
+++ b/sqlalchemy_serializer/serializer.py
@@ -35,6 +35,9 @@ class SerializerMixin(object):
     time_format = '%H:%M'
     decimal_format = '{}'
 
+    # Class of serializer. `Serializer` used by default (if None).
+    serializer_class = None
+
     def get_tzinfo(self):
         """
         Callback to make serializer aware of user's timezone. Should be redefined if needed
@@ -54,7 +57,7 @@ class SerializerMixin(object):
 
     def to_dict(self, only=(), rules=(),
                 date_format=None, datetime_format=None, time_format=None, tzinfo=None,
-                decimal_format=None):
+                decimal_format=None, serializer_class=None):
         """
         Returns SQLAlchemy model's data in JSON compatible format
 
@@ -68,9 +71,10 @@ class SerializerMixin(object):
         :param time_format: str
         :param decimal_format: str
         :param tzinfo: datetime.tzinfo converts datetimes to local user timezone
+        :param serializer_class: type
         :return: data: dict
         """
-        s = Serializer(
+        s = (serializer_class or self.serializer_class or Serializer)(
             date_format=date_format or self.date_format,
             datetime_format=datetime_format or self.datetime_format,
             time_format=time_format or self.time_format,
@@ -133,7 +137,7 @@ class Serializer(object):
         if isinstance(value, self.simple_types) or not isinstance(value, self.complex_types):
             return self.serialize(value)
 
-        serializer = Serializer(**self.opts)
+        serializer = type(self)(**self.opts)
         kwargs = self.schema.fork(key=key)
         logger.info(f'Fork serializer for type:{get_type(value)} with kwargs:{kwargs}')
         return serializer(value, **kwargs)


### PR DESCRIPTION
This update allows to subclassing of `Serializer`.

```
from sqlalchemy_serializer import SerializerMixin, Serializer
from geoalchemy2.elements import WKBElement
from geoalchemy2.shape import to_shape

class SerializerWKB(Serializer):
    def serialize(self, value):
        if isinstance(value, WKBElement):
            p = to_shape(value)
            return p.to_wkt()

        return super().serialize(value)

class SerializerWKBMixin(SerializerMixin):
    serializer_class = SerializerWKB
```

After that we can use new field format:
```
from geoalchemy2 import Geometry

class POI(Base, SerializerWKBMixin):
    __tablename__ = 'poi'
    id = Column(Integer, primary_key=True)
    name = Column(String)
    position = Column(Geometry('POINT'))
```
or
```
from geoalchemy2 import Geometry
from sqlalchemy_serializer import SerializerMixin

class POI(Base, SerializerMixin):
    serializer_class = SerializerWKB
    __tablename__ = 'poi'
    id = Column(Integer, primary_key=True)
    name = Column(String)
    position = Column(Geometry('POINT'))
```

Also we can specify serializer into the `.to_dict(serializer_class=SerializerSubclass)` method.