### PR TITLE
Update Iterable import to avoid deprecation warning

### DIFF
--- a/sqlalchemy_serializer/serializer.py
+++ b/sqlalchemy_serializer/serializer.py
@@ -4,7 +4,13 @@ from enum import Enum
 import logging
 import inspect
 
-from collections import Iterable
+try:
+    # Python 3
+    from collections.abc import Iterable
+except ImportError:
+    # Python 2.7
+    from collections import Iterable
+
 from types import MethodType
 
 from sqlalchemy import inspect as sql_inspect


### PR DESCRIPTION
When running pytest, the following deprecation warning occurred:

```
/usr/local/lib/python3.8/site-packages/sqlalchemy_serializer/serializer.py:7
  /usr/local/lib/python3.8/site-packages/sqlalchemy_serializer/serializer.py:7: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working
    from collections import Iterable

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

This change resolves the warning and prepares for the eventual breaking change in Python 3.9.

A similar solution in https://github.com/pypa/setuptools can be found [here](https://github.com/pypa/setuptools/commit/d4b5eb62d4a848c5cf6e2a0c3c5f39151b31897d#diff-5d2a41039e1a47cd42a2ed61f3611344R99)