### PR TITLE
37 support to custom property

### DIFF
--- a/sqlalchemy_serializer/lib/fields.py
+++ b/sqlalchemy_serializer/lib/fields.py
@@ -1,11 +1,32 @@
+import functools
 import typing as t
+import inspect
 from sqlalchemy import inspect as sql_inspect
 
 
 def get_sql_field_names(model_instance) -> t.Iterable[str]:
     """
-    Returns a set of sql fields names
-    or rises sqlalchemy.exc.NoInspectionAvailable
+    :return:  set of sql fields names
+    :raise:  sqlalchemy.exc.NoInspectionAvailable
     """
     inspector = sql_inspect(model_instance)
     return {a.key for a in inspector.mapper.attrs}
+
+
+def get_property_field_names(model_instance) -> t.Iterable[str]:
+    """
+    :return:  set of field names defined as @property
+    """
+    cls = model_instance.__class__
+    return {
+        name for name, member in inspect.getmembers(cls) if isinstance(member, property)
+    }
+
+
+@functools.lru_cache
+def get_serializable_keys(model_instance) -> t.Iterable:
+    """
+    :return: set of keys available for serialization
+    """
+    result = get_sql_field_names(model_instance)
+    return result

--- a/sqlalchemy_serializer/serializer.py
+++ b/sqlalchemy_serializer/serializer.py
@@ -27,13 +27,13 @@ class SerializerMixin:
 
     # Default exclusive schema.
     # If left blank, serializer becomes greedy and takes all SQLAlchemy-model's attributes
-    serialize_only: tuple = tuple()
+    serialize_only: tuple = ()
 
     # Additions to default schema. Can include negative rules
-    serialize_rules: tuple = tuple()
+    serialize_rules: tuple = ()
 
     # Extra serialising functions
-    serialize_types: tuple = tuple()
+    serialize_types: tuple = ()
 
     date_format = '%Y-%m-%d'
     datetime_format = '%Y-%m-%d %H:%M:%S'
@@ -41,7 +41,10 @@ class SerializerMixin:
     decimal_format = '{}'
 
     # Custom list of fields to serialize in this model
-    serializable_keys = ()
+    serializable_keys: tuple = ()
+
+    # Serialize fields of the model defined as @property automatically
+    auto_serialize_properties: bool = False
 
     def get_tzinfo(self):
         """
@@ -194,7 +197,7 @@ class Serializer:
         res = {}
         keys = self.schema.keys
         if self.schema.is_greedy:
-            keys.update(value.serializable_keys or get_serializable_keys(value))
+            keys.update(get_serializable_keys(value))
 
         for k in keys:
             if self.schema.is_included(key=k):  # TODO: Skip check if is NOT greedy

--- a/sqlalchemy_serializer/serializer.py
+++ b/sqlalchemy_serializer/serializer.py
@@ -9,7 +9,7 @@ from collections.abc import Iterable
 from types import MethodType
 import typing as t
 
-from sqlalchemy_serializer.lib.fields import get_sql_field_names
+from sqlalchemy_serializer.lib.fields import get_serializable_keys
 
 from .lib.schema import Schema
 from .lib import serializable
@@ -40,6 +40,9 @@ class SerializerMixin:
     time_format = '%H:%M'
     decimal_format = '{}'
 
+    # Custom list of fields to serialize in this model
+    serializable_keys = ()
+
     def get_tzinfo(self):
         """
         Callback to make serializer aware of user's timezone. Should be redefined if needed
@@ -49,14 +52,6 @@ class SerializerMixin:
         :return: datetime.tzinfo
         """
         return None
-
-    @property
-    def serializable_keys(self) -> t.Iterable:
-        """
-        :return: set of keys available for serialization
-        """
-        result = get_sql_field_names(self)
-        return result
 
     def to_dict(self, only=(), rules=(),
                 date_format=None, datetime_format=None, time_format=None, tzinfo=None,
@@ -199,7 +194,7 @@ class Serializer:
         res = {}
         keys = self.schema.keys
         if self.schema.is_greedy:
-            keys.update(value.serializable_keys)
+            keys.update(value.serializable_keys or get_serializable_keys(value))
 
         for k in keys:
             if self.schema.is_included(key=k):  # TODO: Skip check if is NOT greedy

--- a/tests/test_flat_model.py
+++ b/tests/test_flat_model.py
@@ -28,6 +28,40 @@ def test_no_defaults_no_rules(get_instance):
     assert 'money' not in data
 
 
+def test_no_defaults_no_rules_with_auto_serialize_properties(get_instance):
+    """
+    Checks to_dict method of flat model with no predefined options
+    but with automatic serialization of @properties
+    """
+    class AutoPropFlatModel(FlatModel):
+        auto_serialize_properties = True
+
+    i = get_instance(AutoPropFlatModel)
+    data = i.to_dict()
+
+    # Check SQLAlchemy fields
+    assert 'id' in data
+    assert 'string' in data and data['string'] == i.string
+    assert 'date' in data
+    assert 'time' in data
+    assert 'datetime' in data
+    assert 'bool' in data and data['bool'] == i.bool
+    assert 'null' in data and data['null'] is None
+    assert 'uuid' in data and str(i.uuid) == data['uuid']
+
+    # Properties
+    assert 'prop' in data
+    assert 'prop_with_bytes' in data
+
+    # Check non-sql fields
+    assert 'list' not in data
+    assert 'set' not in data
+    assert 'dict' not in data
+    assert 'method' not in data
+    assert '_protected_method' not in data
+    assert 'money' not in data
+
+
 def test_default_formats(get_instance):
     """
     Check date/datetime/time/decimal default formats in resulting JSON of flat model with no predefined options

--- a/tests/test_get_property_field_names_function.py
+++ b/tests/test_get_property_field_names_function.py
@@ -1,0 +1,11 @@
+from sqlalchemy_serializer.lib.fields import get_property_field_names
+
+from .models import FlatModel
+
+
+def test_get_property_field_names__returns_result(get_instance):
+    instance = get_instance(FlatModel)
+    assert get_property_field_names(instance) == {
+        "prop",
+        "prop_with_bytes",
+    }

--- a/tests/test_get_serializable_keys_function.py
+++ b/tests/test_get_serializable_keys_function.py
@@ -1,0 +1,42 @@
+from sqlalchemy_serializer.lib.fields import get_serializable_keys
+from tests.models import FlatModel
+
+
+def test_get_serializable_keys__custom_only(get_instance):
+    instance = get_instance(FlatModel)
+    instance.serializable_keys = ("id", "string")
+    assert get_serializable_keys(instance) == {"id", "string"}
+
+
+def test_get_serializable_keys__sql_only(get_instance):
+    instance = get_instance(FlatModel)
+    assert not instance.serializable_keys
+    assert not instance.auto_serialize_properties
+    assert get_serializable_keys(instance) == {
+        "id",
+        "string",
+        "date",
+        "datetime",
+        "time",
+        "bool",
+        "null",
+        "uuid",
+    }
+
+
+def test_get_serializable_keys__auto_serialize_propereties(get_instance):
+    instance = get_instance(FlatModel)
+    instance.auto_serialize_properties = True
+    assert not instance.serializable_keys
+    assert get_serializable_keys(instance) == {
+        "id",
+        "string",
+        "date",
+        "datetime",
+        "time",
+        "bool",
+        "null",
+        "uuid",
+        "prop",
+        "prop_with_bytes",
+    }


### PR DESCRIPTION
Support automatic serialisation of the fields declared as `@property`

Usage:
```python
# Custom serializer
from sqlalchemy_serializer import SerializerMixin

class CustomSerializerMixin(SerializerMixin):
    auto_serialize_properties = True
 
# Inline in a certain model
class Model(Base, SerializerMixin):
    auto_serialize_properties = True
```