### PR TITLE
Introduce serializer fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import logging
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
+from sqlalchemy_serializer.serializer import Serializer
 from .models import Base
 
 
@@ -12,8 +13,11 @@ logger = logging.getLogger("serializer")
 logger.setLevel(logging.DEBUG)
 
 
-DATETIME_FORMAT = "%Y-%m-%d %H:%M"
-DATE_FORMAT = "%Y-%m-%d"
+DEFAULT_DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+DEFAULT_DATE_FORMAT = "%Y-%m-%d"
+DEFAULT_TIME_FORMAT = "%H:%M"
+DEFAULT_DECIMAL_FORMAT = "{}"
+
 
 DB_HOST = os.environ.get("POSTGRES_HOST")
 DB_PORT = os.environ.get("POSTGRES_PORT", 5432)
@@ -54,3 +58,22 @@ def get_instance(session):
         return instance
 
     return func
+
+
+@pytest.fixture
+def serializer(
+    date_format=DEFAULT_DATE_FORMAT,
+    datetime_format=DEFAULT_DATETIME_FORMAT,
+    time_format=DEFAULT_TIME_FORMAT,
+    decimal_format=DEFAULT_DECIMAL_FORMAT,
+    tzinfo=None,
+    serialize_types=(),
+):
+    return Serializer(
+        date_format=date_format,
+        datetime_format=datetime_format,
+        time_format=time_format,
+        decimal_format=decimal_format,
+        tzinfo=tzinfo,
+        serialize_types=serialize_types,
+    )

--- a/tests/test_serializer_fork_function.py
+++ b/tests/test_serializer_fork_function.py
@@ -1,22 +1,4 @@
-import pytest
-
-from sqlalchemy_serializer.serializer import Serializer
-
-
-@pytest.fixture
-def test_class():
-    serializer = Serializer(
-        date_format="%Y-%m-%d",
-        datetime_format="%Y-%m-%d %H:%M:%S",
-        time_format="%H:%M",
-        decimal_format="{}",
-        tzinfo=None,
-        serialize_types=(),
-    )
-    return serializer
-
-
-def test_fork_with_none_key(mocker, test_class):
+def test_fork_with_none_key(mocker, serializer):
     value = "test_value"
     expected = "serialized"
     schema = mocker.MagicMock()
@@ -24,14 +6,14 @@ def test_fork_with_none_key(mocker, test_class):
         "sqlalchemy_serializer.serializer.Serializer.__call__", return_value=expected
     )
 
-    with mocker.patch.object(test_class, "schema", schema):
-        result = test_class.fork(value)
+    with mocker.patch.object(serializer, "schema", schema):
+        result = serializer.fork(value)
 
     assert result == expected
     schema.fork.assert_not_called()
 
 
-def test_fork_with_key(mocker, test_class):
+def test_fork_with_key(mocker, serializer):
     value, key, expected = "test_value", "test_key", "serialized"
     schema = mocker.MagicMock()
 
@@ -39,18 +21,18 @@ def test_fork_with_key(mocker, test_class):
         "sqlalchemy_serializer.serializer.Serializer.__call__", return_value=expected
     )
 
-    with mocker.patch.object(test_class, "schema", schema):
-        result = test_class.fork(value=value, key=key)
+    with mocker.patch.object(serializer, "schema", schema):
+        result = serializer.fork(value=value, key=key)
 
     assert result == expected
     schema.fork.assert_called_once_with(key=key)
 
 
-def test_fork_logger(mocker, test_class):
+def test_fork_logger(mocker, serializer):
     mocked_logger = mocker.patch("sqlalchemy_serializer.serializer.logger")
     mocker.patch("sqlalchemy_serializer.serializer.Serializer.__call__")
 
-    with mocker.patch.object(test_class, "schema", mocker.MagicMock()):
-        test_class.fork("value")
+    with mocker.patch.object(serializer, "schema", mocker.MagicMock()):
+        serializer.fork("value")
 
     mocked_logger.debug.assert_called_once_with("Fork serializer for type:%s", "str")

--- a/tests/test_serializer_set_recursion_depth_function.py
+++ b/tests/test_serializer_set_recursion_depth_function.py
@@ -1,23 +1,5 @@
-import pytest
-
-from sqlalchemy_serializer.serializer import Serializer
-
-
-@pytest.fixture
-def test_class():
-    serializer = Serializer(
-        date_format="%Y-%m-%d",
-        datetime_format="%Y-%m-%d %H:%M:%S",
-        time_format="%H:%M",
-        decimal_format="{}",
-        tzinfo=None,
-        serialize_types=(),
-    )
-    return serializer
-
-
-def test_set_recursion_depth_success(test_class):
+def test_set_recursion_depth_success(serializer):
     new_recursion_depth = 123
-    assert test_class.recursion_depth == 0
-    test_class.set_recursion_depth(new_recursion_depth)
-    assert test_class.recursion_depth == new_recursion_depth
+    assert serializer.recursion_depth == 0
+    serializer.set_recursion_depth(new_recursion_depth)
+    assert serializer.recursion_depth == new_recursion_depth


### PR DESCRIPTION
Serializer fixture is useful for better  regress testing. 
We  can parametrise  it and use in all available tests. So we  can run all the existing tests  against  different setsss  of the initial settings